### PR TITLE
fix: the gtdb_db for the mag demo

### DIFF
--- a/30-applications/02-genomics/mag/mag_workflow.ipynb
+++ b/30-applications/02-genomics/mag/mag_workflow.ipynb
@@ -47,7 +47,8 @@
     "# Declare URLs to download necessary files\n",
     "kraken2_db = \"https://raw.githubusercontent.com/nf-core/test-datasets/mag/test_data/minigut_kraken.tgz\"\n",
     "centrifuge_db = \"https://raw.githubusercontent.com/nf-core/test-datasets/mag/test_data/minigut_cf.tar.gz\"\n",
-    "busco_db = \"https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2024-01-08.tar.gz\""
+    "busco_db = \"https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2024-01-08.tar.gz\"\n",
+    "gtdb_db = \"https://data.ace.uq.edu.au/public/gtdb/data/releases/release220/220.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r220_data.tar.gz\""
    ]
   },
   {
@@ -67,6 +68,7 @@
     "        \"--kraken2_db\": kraken2_db,\n",
     "        \"--centrifuge_db\": centrifuge_db,\n",
     "        \"--busco_db\": busco_db,\n",
+    "        \"--gtdb_db\": gtdb_db,\n",
     "        \"--skip_krona\": \"true\",\n",
     "        \"--skip_gtdbtk\": \"true\",\n",
     "        \"--skip_maxbin2\": \"true\",\n",


### PR DESCRIPTION
Update the `gtdb_db = "https://data.ace.uq.edu.au/public/gtdb/data/releases/release220/220.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r220_data.tar.gz"` in mag demo

![image](https://github.com/user-attachments/assets/38133bd7-8dba-4d45-b08f-0ed958b790a8)
